### PR TITLE
#61 [SPARK-29284][SQL] Adaptive query execution works correctly when …

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ExchangeCoordinator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ExchangeCoordinator.scala
@@ -237,7 +237,7 @@ class ExchangeCoordinator(
       // number of post-shuffle partitions.
       val partitionStartIndices =
         if (mapOutputStatistics.length == 0) {
-          Array.empty[Int]
+          Array(0)
         } else {
           estimatePartitionStartIndices(mapOutputStatistics)
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExchangeCoordinatorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExchangeCoordinatorSuite.scala
@@ -527,4 +527,15 @@ class ExchangeCoordinatorSuite extends SparkFunSuite with BeforeAndAfterAll {
     }
     withSparkSession(test, 4, None)
   }
+
+  test("SPARK-29284 adaptive query execution works correctly " +
+    "when first stage partitions size is 0") {
+    val test = { spark: SparkSession =>
+      spark.sql("SET spark.sql.adaptive.enabled=true")
+      spark.sql("SET spark.sql.shuffle.partitions=1")
+      val resultDf = spark.range(0).distinct().groupBy().count()
+      checkAnswer(resultDf, Row(0) :: Nil)
+    }
+    withSparkSession(test, 4, None)
+  }
 }


### PR DESCRIPTION
…first stage partitions size is 0

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
