### PR TITLE
KE-16620 add spark.sql.sort.enableShuffleRadixSort to control radix sort on shuffle exchange

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -217,6 +217,15 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
+  val SHUFFLE_RADIX_SORT_ENABLED = buildConf("spark.sql.sort.enableShuffleRadixSort")
+    .internal()
+    .doc("When true, enable use of radix sort when shuffle exchange. " +
+      "Radix sort is much faster but " +
+      "requires additional memory to be reserved up-front. The memory overhead may be " +
+      "significant when sorting very small rows (up to 50% more in this case).")
+    .booleanConf
+    .createWithDefault(false)
+
   val AUTO_BROADCASTJOIN_THRESHOLD = buildConf("spark.sql.autoBroadcastJoinThreshold")
     .doc("Configures the maximum size in bytes for a table that will be broadcast to all worker " +
       "nodes when performing a join.  By setting this value to -1 broadcasting can be disabled. " +
@@ -1799,6 +1808,8 @@ class SQLConf extends Serializable with Logging {
   def preferSortMergeJoin: Boolean = getConf(PREFER_SORTMERGEJOIN)
 
   def enableRadixSort: Boolean = getConf(RADIX_SORT_ENABLED)
+
+  def enableShuffleRadixSort: Boolean = getConf(SHUFFLE_RADIX_SORT_ENABLED)
 
   def isParquetSchemaMergingEnabled: Boolean = getConf(PARQUET_SCHEMA_MERGING_ENABLED)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
@@ -272,6 +272,7 @@ object ShuffleExchangeExec {
           }
           // The comparator for comparing row hashcode, which should always be Integer.
           val prefixComparator = PrefixComparators.LONG
+          val canUseRadixSort = SQLConf.get.enableShuffleRadixSort
           // The prefix computer generates row hashcode as the prefix, so we may decrease the
           // probability that the prefixes are equal when input rows choose column values from a
           // limited range.
@@ -293,7 +294,7 @@ object ShuffleExchangeExec {
             prefixComparator,
             prefixComputer,
             pageSize,
-            false)
+            canUseRadixSort)
           sorter.sort(iter.asInstanceOf[Iterator[UnsafeRow]])
         }
       } else {


### PR DESCRIPTION
revert forbidden radix sort