### PR TITLE
KE-19990, [spark3] Support skip.header.line.count option in Hive table

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -31,13 +31,13 @@ import org.apache.hadoop.hive.serde2.Deserializer
 import org.apache.hadoop.hive.serde2.objectinspector.{ObjectInspectorConverters, StructObjectInspector}
 import org.apache.hadoop.hive.serde2.objectinspector.primitive._
 import org.apache.hadoop.io.Writable
-import org.apache.hadoop.mapred.{FileInputFormat, InputFormat => oldInputClass, JobConf}
+import org.apache.hadoop.mapred.{FileInputFormat, FileSplit, InputFormat => oldInputClass, JobConf, TextInputFormat}
 import org.apache.hadoop.mapreduce.{InputFormat => newInputClass}
 
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.internal.Logging
-import org.apache.spark.rdd.{EmptyRDD, HadoopRDD, NewHadoopRDD, RDD, UnionRDD}
+import org.apache.spark.rdd.{EmptyRDD, HadoopPartition, HadoopRDD, NewHadoopRDD, RDD, UnionRDD}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.{InternalRow, SQLConfHelper}
 import org.apache.spark.sql.catalyst.analysis.CastSupport
@@ -122,6 +122,10 @@ class HadoopTableReader(
 
     val tablePath = hiveTable.getPath
     val inputPathStr = applyFilterIfNeeded(tablePath, filterOpt)
+    val skipHeaderLineCount = tableDesc.getProperties
+      .getProperty("skip.header.line.count", "0").toInt
+    val isTextInputFormatTable = classOf[TextInputFormat]
+      .isAssignableFrom(hiveTable.getInputFormatClass)
 
     // logDebug("Table input: %s".format(tablePath))
     val hadoopRDD = createHadoopRDD(localTableDesc, inputPathStr)
@@ -129,11 +133,23 @@ class HadoopTableReader(
     val attrsWithIndex = attributes.zipWithIndex
     val mutableRow = new SpecificInternalRow(attributes.map(_.dataType))
 
-    val deserializedHadoopRDD = hadoopRDD.mapPartitions { iter =>
+    val deserializedHadoopRDD = hadoopRDD.mapPartitionsWithIndex { (index, iter) =>
       val hconf = broadcastedHadoopConf.value.value
       val deserializer = deserializerClass.getConstructor().newInstance()
       DeserializerLock.synchronized {
         deserializer.initialize(hconf, localTableDesc.getProperties)
+      }
+      if (skipHeaderLineCount > 0 && isTextInputFormatTable) {
+        hadoopRDD.partitions(index) match {
+          case partition: HadoopPartition =>
+            if (partition.inputSplit.t.asInstanceOf[FileSplit].getStart() == 0) {
+              var i = 0
+              while (i < skipHeaderLineCount && iter.hasNext) {
+                i += 1
+                iter.next()
+              }
+            }
+        }
       }
       HadoopTableReader.fillObject(iter, deserializer, attrsWithIndex, mutableRow, deserializer)
     }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -2583,6 +2583,56 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
       }
     }
   }
+
+  test("SPARK-11374 Support skip.header.line.count option in Hive table") {
+    withTable("skip_table_0", "skip_table_1", "skip_table_2", "skip_table_3", "skip_table_4") {
+      withTempDir { dir =>
+        dir.delete()
+        val path = dir.getCanonicalPath
+        spark.range(0, 3).map(x => (x, s"c$x")).repartition(1).write.csv(path)
+        spark.range(3, 6).map(x => (x, s"c$x")).repartition(1).write.mode(SaveMode.Append).csv(path)
+        for (i <- 0 to 4) {
+          sql(
+            s"""
+               |CREATE EXTERNAL TABLE skip_table_$i (id INT, b VARCHAR(10))
+               |ROW FORMAT DELIMITED
+               |FIELDS TERMINATED BY ','
+               |STORED AS TEXTFILE LOCATION '$path'
+               |${if (i == 0) "" else s"TBLPROPERTIES('skip.header.line.count'='$i')"}
+            """.stripMargin)
+          val result = if (i == 0) {
+            Seq(Row(0, "c0"), Row(1, "c1"), Row(2, "c2"), Row(3, "c3"), Row(4, "c4"), Row(5, "c5"))
+          } else if (i == 1) {
+            Seq(Row(1, "c1"), Row(2, "c2"), Row(4, "c4"), Row(5, "c5"))
+          } else if (i == 2) {
+            Seq(Row(2, "c2"), Row(5, "c5"))
+          } else {
+            Seq.empty[Row]
+          }
+          checkAnswer(sql(s"SELECT * FROM skip_table_$i"), result)
+        }
+      }
+    }
+
+    // Since the default value of fs.local.block.size is 32MB (32 * 1024 * 1024),
+    // the following creates a file with three input splits.
+    withTable("skip_table_5") {
+      withTempDir { dir =>
+        dir.delete()
+        val path = dir.getCanonicalPath
+        spark.range(0, 3 * 1024 * 1024).map(x => "c" * 32).repartition(1).write.csv(path)
+        sql(
+          s"""
+             |CREATE EXTERNAL TABLE skip_table_5 (id INT, b VARCHAR(10))
+             |ROW FORMAT DELIMITED
+             |FIELDS TERMINATED BY ','
+             |STORED AS TEXTFILE LOCATION '$path'
+             |TBLPROPERTIES('skip.header.line.count'='1')
+          """.stripMargin)
+        checkAnswer(sql(s"SELECT count(*) FROM skip_table_5"), Row(3 * 1024 * 1024 - 1) :: Nil)
+      }
+    }
+  }
 }
 
 @SlowHiveTest


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
