### PR TITLE
KE-14216 Avoid sparder driver OOM for decoding data

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1154,7 +1154,7 @@ object SQLConf {
       "This is similar to spark.driver.maxResultSize but it enforces the limit on the " +
       "uncompressed result. Specifying this can help protect the driver from out-of-memory errors.")
     .bytesConf(ByteUnit.BYTE)
-    .createWithDefaultString("1024m")
+    .createWithDefaultString("3600m")
 
   val CODEGEN_FACTORY_MODE = buildConf("spark.sql.codegen.factoryMode")
     .doc("This config determines the fallback behavior of several codegen generators " +
@@ -3212,7 +3212,7 @@ class SQLConf extends Serializable with Logging {
     }
   }
 
-  def maxCollectSize: Option[Long] = getConf(SQLConf.MAX_COLLECT_SIZE)
+  def maxCollectSize: Long = getConf(SQLConf.MAX_COLLECT_SIZE)
 
   def adaptiveExecutionEnabled: Boolean = getConf(ADAPTIVE_EXECUTION_ENABLED)
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/SizeLimitingByteArrayUnsafeRowsConverter.scala
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/SizeLimitingByteArrayUnsafeRowsConverter.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 import org.apache.spark.util.Utils
 
 private[spark] class SizeLimitingByteArrayUnsafeRowsConverter(
-                                                               maxCollectSize: Option[Long]
+                                                               maxCollectSize: Long
                                                              ) extends Logging {
   private var totalUncompressedResultSize = 0L
 
@@ -109,15 +109,12 @@ private[spark] class SizeLimitingByteArrayUnsafeRowsConverter(
 
   private def ensureTotalSizeIsBelowLimit(sizeOfNextRow: Int): Unit = {
     totalUncompressedResultSize += sizeOfNextRow
-    maxCollectSize match {
-      case Some(maxSize) => if (totalUncompressedResultSize > maxSize) {
-        val msg = s"Total size of uncompressed results " +
-          s"(${Utils.bytesToString(totalUncompressedResultSize)}) " +
-          s"is bigger than the limit of (${Utils.bytesToString(maxSize)})"
-        logError(msg)
-        throw new SparkException(msg)
-      }
-      case _ =>
+    if (totalUncompressedResultSize > sizeOfNextRow) {
+      val msg = s"Total size of uncompressed results " +
+        s"(${Utils.bytesToString(totalUncompressedResultSize)}) " +
+        s"is bigger than the limit of (${Utils.bytesToString(sizeOfNextRow)})"
+      logError(msg)
+      throw new SparkException(msg)
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
