### PR TITLE
SPARK-34800 use fine-grained lock in SessionCatalog.tableExists

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -458,8 +458,8 @@ class SessionCatalog(
    * Return whether a table/view with the specified name exists. If no database is specified, check
    * with current database.
    */
-  def tableExists(name: TableIdentifier): Boolean = synchronized {
-    val db = formatDatabaseName(name.database.getOrElse(currentDb))
+  def tableExists(name: TableIdentifier): Boolean = {
+    val db = formatDatabaseName(name.database.getOrElse(getCurrentDatabase))
     val table = formatTableName(name.table)
     externalCatalog.tableExists(db, table)
   }


### PR DESCRIPTION
**What changes were proposed in this pull request?**
Use fine-grained lock in SessionCatalog.tableExists, in order to lock currentDB variable rather than lock tableExists method which will block inner external catalog's behaviour.

**Why are the changes needed?**
We have modified the underlying hive meta store which a different hive database is placed in its own shard for performance. However, we found that the synchronized lock limits the concurrency.

**How was this patch tested?**
Existing tests.
