### PR TITLE
KE-29976:  spark.sql.orc.filterPushdown not working with Spark 3.1.1 …

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/common/kvstore/pom.xml
+++ b/common/kvstore/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/common/network-common/pom.xml
+++ b/common/network-common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/common/network-shuffle/pom.xml
+++ b/common/network-shuffle/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/common/network-yarn/pom.xml
+++ b/common/network-yarn/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/common/sketch/pom.xml
+++ b/common/sketch/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/common/tags/pom.xml
+++ b/common/tags/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/common/unsafe/pom.xml
+++ b/common/unsafe/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/external/avro/pom.xml
+++ b/external/avro/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/external/docker-integration-tests/pom.xml
+++ b/external/docker-integration-tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/external/kafka-0-10-assembly/pom.xml
+++ b/external/kafka-0-10-assembly/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/external/kafka-0-10-sql/pom.xml
+++ b/external/kafka-0-10-sql/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/external/kafka-0-10-token-provider/pom.xml
+++ b/external/kafka-0-10-token-provider/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/external/kafka-0-10/pom.xml
+++ b/external/kafka-0-10/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/external/kinesis-asl-assembly/pom.xml
+++ b/external/kinesis-asl-assembly/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/external/kinesis-asl/pom.xml
+++ b/external/kinesis-asl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/external/spark-ganglia-lgpl/pom.xml
+++ b/external/spark-ganglia-lgpl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/graphx/pom.xml
+++ b/graphx/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/hadoop-cloud/pom.xml
+++ b/hadoop-cloud/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/launcher/pom.xml
+++ b/launcher/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/mllib-local/pom.xml
+++ b/mllib-local/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/mllib/pom.xml
+++ b/mllib/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   </parent>
   <groupId>org.apache.spark</groupId>
   <artifactId>spark-parent_2.12</artifactId>
-  <version>3.1.1-kylin-4.x-r32</version>
+  <version>3.1.1-kylin-4.x-r33</version>
   <packaging>pom</packaging>
   <name>Spark Project Parent POM</name>
   <url>http://spark.apache.org/</url>

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/resource-managers/kubernetes/core/pom.xml
+++ b/resource-managers/kubernetes/core/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/resource-managers/kubernetes/integration-tests/pom.xml
+++ b/resource-managers/kubernetes/integration-tests/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/resource-managers/mesos/pom.xml
+++ b/resource-managers/mesos/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/resource-managers/yarn/pom.xml
+++ b/resource-managers/yarn/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/sql/catalyst/pom.xml
+++ b/sql/catalyst/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/sql/hive-thriftserver/pom.xml
+++ b/sql/hive-thriftserver/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/streaming/pom.xml
+++ b/streaming/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.1.1-kylin-4.x-r32</version>
+    <version>3.1.1-kylin-4.x-r33</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
…for tables with varchar data type

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
