### PR TITLE
KE-36499 fix replace function when  second argument is "" pushdown error

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -526,13 +526,18 @@ case class StringReplace(srcExpr: Expression, searchExpr: Expression, replaceExp
   }
 
   override def nullSafeEval(srcEval: Any, searchEval: Any, replaceEval: Any): Any = {
-    srcEval.asInstanceOf[UTF8String].replace(
-      searchEval.asInstanceOf[UTF8String], replaceEval.asInstanceOf[UTF8String])
+    val s = srcEval.asInstanceOf[UTF8String].clone().toString().replace(
+      searchEval.asInstanceOf[UTF8String].clone().toString()
+      , replaceEval.asInstanceOf[UTF8String].clone().toString())
+    val ss = UTF8String.fromString(s)
+    ss
   }
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     nullSafeCodeGen(ctx, ev, (src, search, replace) => {
-      s"""${ev.value} = $src.replace($search, $replace);"""
+      s"""${ev.value} =
+         | UTF8String.fromString($src.toString().replace($search.toString(), $replace.toString()));
+         | """.stripMargin
     })
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.UTF8String
 
 class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
 
@@ -427,6 +428,9 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("replace") {
+    val stringReplaceExpression = StringReplace(Literal(""), Literal(""), Literal("vv"))
+    val stringReplaceResult = stringReplaceExpression.eval(null)
+    assert(stringReplaceResult.equals(UTF8String.fromString("vv")))
     checkEvaluation(
       StringReplace(Literal("replace"), Literal("pl"), Literal("123")), "re123ace")
     checkEvaluation(StringReplace(Literal("replace"), Literal("pl"), Literal("")), "reace")


### PR DESCRIPTION
KE-36499 fix replace function when  second argument is "" pushdown error