### PR TITLE
[KE-37091][SPARK-34980][SQL] Support coalesce partition through union in AQE

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
@@ -17,9 +17,11 @@
 
 package org.apache.spark.sql.execution.adaptive
 
+import scala.collection.mutable
+
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
-import org.apache.spark.sql.execution.{ShufflePartitionSpec, SparkPlan}
+import org.apache.spark.sql.execution.{ShufflePartitionSpec, SparkPlan, UnaryExecNode, UnionExec}
 import org.apache.spark.sql.execution.exchange.{ENSURE_REQUIREMENTS, REBALANCE_PARTITIONS_BY_COL, REBALANCE_PARTITIONS_BY_NONE, REPARTITION_BY_COL, ShuffleExchangeLike, ShuffleOrigin}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.Utils
@@ -42,69 +44,112 @@ case class CoalesceShufflePartitions(session: SparkSession) extends AQEShuffleRe
     if (!conf.coalesceShufflePartitionsEnabled) {
       return plan
     }
-    if (!plan.collectLeaves().forall(_.isInstanceOf[QueryStageExec])) {
-      // If not all leaf nodes are query stages, it's not safe to reduce the number of
-      // shuffle partitions, because we may break the assumption that all children of a spark plan
-      // have same number of output partitions.
-      return plan
-    }
 
-    def collectShuffleStageInfos(plan: SparkPlan): Seq[ShuffleStageInfo] = plan match {
-      case ShuffleStageInfo(stage, specs) => Seq(new ShuffleStageInfo(stage, specs))
-      case _ => plan.children.flatMap(collectShuffleStageInfos)
-    }
-
-    val shuffleStageInfos = collectShuffleStageInfos(plan)
-    // ShuffleExchanges introduced by repartition do not support changing the number of partitions.
-    // We change the number of partitions in the stage only if all the ShuffleExchanges support it.
-    if (!shuffleStageInfos.forall(s => isSupported(s.shuffleStage.shuffle))) {
-      plan
-    } else {
-      // Ideally, this rule should simply coalesce partitions w.r.t. the target size specified by
-      // ADVISORY_PARTITION_SIZE_IN_BYTES (default 64MB). To avoid perf regression in AQE, this
-      // rule by default tries to maximize the parallelism and set the target size to
-      // `total shuffle size / Spark default parallelism`. In case the `Spark default parallelism`
-      // is too big, this rule also respect the minimum partition size specified by
-      // COALESCE_PARTITIONS_MIN_PARTITION_SIZE (default 1MB).
-      // For history reason, this rule also need to support the config
-      // COALESCE_PARTITIONS_MIN_PARTITION_NUM. We should remove this config in the future.
-      val minNumPartitions = conf.getConf(SQLConf.COALESCE_PARTITIONS_MIN_PARTITION_NUM).getOrElse {
-        if (conf.getConf(SQLConf.COALESCE_PARTITIONS_PARALLELISM_FIRST)) {
-          // We fall back to Spark default parallelism if the minimum number of coalesced partitions
-          // is not set, so to avoid perf regressions compared to no coalescing.
-          session.sparkContext.defaultParallelism
-        } else {
-          // If we don't need to maximize the parallelism, we set `minPartitionNum` to 1, so that
-          // the specified advisory partition size will be respected.
-          1
-        }
-      }
-      val advisoryTargetSize = conf.getConf(SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES)
-      val minPartitionSize = if (Utils.isTesting) {
-        // In the tests, we usually set the target size to a very small value that is even smaller
-        // than the default value of the min partition size. Here we also adjust the min partition
-        // size to be not larger than 20% of the target size, so that the tests don't need to set
-        // both configs all the time to check the coalescing behavior.
-        conf.getConf(SQLConf.COALESCE_PARTITIONS_MIN_PARTITION_SIZE).min(advisoryTargetSize / 5)
+    // Ideally, this rule should simply coalesce partitions w.r.t. the target size specified by
+    // ADVISORY_PARTITION_SIZE_IN_BYTES (default 64MB). To avoid perf regression in AQE, this
+    // rule by default tries to maximize the parallelism and set the target size to
+    // `total shuffle size / Spark default parallelism`. In case the `Spark default parallelism`
+    // is too big, this rule also respect the minimum partition size specified by
+    // COALESCE_PARTITIONS_MIN_PARTITION_SIZE (default 1MB).
+    // For history reason, this rule also need to support the config
+    // COALESCE_PARTITIONS_MIN_PARTITION_NUM. We should remove this config in the future.
+    val minNumPartitions = conf.getConf(SQLConf.COALESCE_PARTITIONS_MIN_PARTITION_NUM).getOrElse {
+      if (conf.getConf(SQLConf.COALESCE_PARTITIONS_PARALLELISM_FIRST)) {
+        // We fall back to Spark default parallelism if the minimum number of coalesced partitions
+        // is not set, so to avoid perf regressions compared to no coalescing.
+        session.sparkContext.defaultParallelism
       } else {
-        conf.getConf(SQLConf.COALESCE_PARTITIONS_MIN_PARTITION_SIZE)
+        // If we don't need to maximize the parallelism, we set `minPartitionNum` to 1, so that
+        // the specified advisory partition size will be respected.
+        1
       }
+    }
+    val advisoryTargetSize = conf.getConf(SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES)
+    val minPartitionSize = if (Utils.isTesting) {
+      // In the tests, we usually set the target size to a very small value that is even smaller
+      // than the default value of the min partition size. Here we also adjust the min partition
+      // size to be not larger than 20% of the target size, so that the tests don't need to set
+      // both configs all the time to check the coalescing behavior.
+      conf.getConf(SQLConf.COALESCE_PARTITIONS_MIN_PARTITION_SIZE).min(advisoryTargetSize / 5)
+    } else {
+      conf.getConf(SQLConf.COALESCE_PARTITIONS_MIN_PARTITION_SIZE)
+    }
+
+    // Sub-plans under the Union operator can be coalesced independently, so we can divide them
+    // into independent "coalesce groups", and all shuffle stages within each group have to be
+    // coalesced together.
+    val coalesceGroups = collectCoalesceGroups(plan)
+
+    // Divide minimum task parallelism among coalesce groups according to their data sizes.
+    val minNumPartitionsByGroup = if (coalesceGroups.length == 1) {
+      Seq(math.max(minNumPartitions, 1))
+    } else {
+      val sizes =
+        coalesceGroups.map(_.flatMap(_.shuffleStage.mapStats.map(_.bytesByPartitionId.sum)).sum)
+      val totalSize = sizes.sum
+      sizes.map { size =>
+        val num = if (totalSize > 0) {
+          math.round(minNumPartitions * 1.0 * size / totalSize)
+        } else {
+          minNumPartitions
+        }
+        math.max(num.toInt, 1)
+      }
+    }
+
+    val specsMap = mutable.HashMap.empty[Int, Seq[ShufflePartitionSpec]]
+    // Coalesce partitions for each coalesce group independently.
+    coalesceGroups.zip(minNumPartitionsByGroup).foreach { case (shuffleStages, minNumPartitions) =>
       val newPartitionSpecs = ShufflePartitionsUtil.coalescePartitions(
-        shuffleStageInfos.map(_.shuffleStage.mapStats),
-        shuffleStageInfos.map(_.partitionSpecs),
+        shuffleStages.map(_.shuffleStage.mapStats),
+        shuffleStages.map(_.partitionSpecs),
         advisoryTargetSize = advisoryTargetSize,
         minNumPartitions = minNumPartitions,
         minPartitionSize = minPartitionSize)
 
       if (newPartitionSpecs.nonEmpty) {
-        val specsMap = shuffleStageInfos.zip(newPartitionSpecs).map { case (stageInfo, partSpecs) =>
-          (stageInfo.shuffleStage.id, partSpecs)
-        }.toMap
-        updateShuffleReads(plan, specsMap)
-      } else {
-        plan
+        shuffleStages.zip(newPartitionSpecs).map { case (stageInfo, partSpecs) =>
+          specsMap.put(stageInfo.shuffleStage.id, partSpecs)
+        }
       }
     }
+
+    if (specsMap.nonEmpty) {
+      updateShuffleReads(plan, specsMap.toMap)
+    } else {
+      plan
+    }
+  }
+
+  /**
+   * Gather all coalesce-able groups such that the shuffle stages in each child of a Union operator
+   * are in their independent groups if:
+   * 1) all leaf nodes of this child are shuffle stages; and
+   * 2) all these shuffle stages support coalescing.
+   */
+  private def collectCoalesceGroups(plan: SparkPlan): Seq[Seq[ShuffleStageInfo]] = plan match {
+    case r @ AQEShuffleReadExec(q: ShuffleQueryStageExec, _) if isSupported(q.shuffle) =>
+      Seq(collectShuffleStageInfos(r))
+    case unary: UnaryExecNode => collectCoalesceGroups(unary.child)
+    case union: UnionExec => union.children.flatMap(collectCoalesceGroups)
+    // If not all leaf nodes are query stages, it's not safe to reduce the number of shuffle
+    // partitions, because we may break the assumption that all children of a spark plan have
+    // same number of output partitions.
+    case p if p.collectLeaves().forall(_.isInstanceOf[QueryStageExec]) =>
+      val shuffleStages = collectShuffleStageInfos(p)
+      // ShuffleExchanges introduced by repartition do not support partition number change.
+      // We change the number of partitions only if all the ShuffleExchanges support it.
+      if (shuffleStages.forall(s => isSupported(s.shuffleStage.shuffle))) {
+        Seq(shuffleStages)
+      } else {
+        Seq.empty
+      }
+    case _ => Seq.empty
+  }
+
+  private def collectShuffleStageInfos(plan: SparkPlan): Seq[ShuffleStageInfo] = plan match {
+    case ShuffleStageInfo(stage, specs) => Seq(new ShuffleStageInfo(stage, specs))
+    case _ => plan.children.flatMap(collectShuffleStageInfos)
   }
 
   private def updateShuffleReads(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/CoalesceShufflePartitionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/CoalesceShufflePartitionsSuite.scala
@@ -410,14 +410,14 @@ class CoalesceShufflePartitionsSuite extends SparkFunSuite with BeforeAndAfterAl
 
       QueryTest.checkAnswer(resultDf, Seq((0), (1), (2), (3)).map(i => Row(i)))
 
+      // Shuffle partition coalescing of the join is performed independent of the non-grouping
+      // aggregate on the other side of the union.
       val finalPlan = resultDf.queryExecution.executedPlan
         .asInstanceOf[AdaptiveSparkPlanExec].executedPlan
-      // As the pre-shuffle partition number are different, we will skip reducing
-      // the shuffle partition numbers.
       assert(
         finalPlan.collect {
           case r @ CoalescedShuffleRead() => r
-        }.isEmpty)
+        }.size == 2)
     }
     withSparkSession(test, 100, None)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent, SparkListe
 import org.apache.spark.sql.{Dataset, QueryTest, Row, SparkSession, Strategy}
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LogicalPlan}
-import org.apache.spark.sql.execution.{CommandResultExec, LocalTableScanExec, PartialReducerPartitionSpec, QueryExecution, ReusedSubqueryExec, ShuffledRowRDD, SortExec, SparkPlan, UnaryExecNode}
+import org.apache.spark.sql.execution.{CommandResultExec, LocalTableScanExec, PartialReducerPartitionSpec, QueryExecution, ReusedSubqueryExec, ShuffledRowRDD, SortExec, SparkPlan, UnaryExecNode, UnionExec}
 import org.apache.spark.sql.execution.command.DataWritingCommandExec
 import org.apache.spark.sql.execution.datasources.noop.NoopDataSource
 import org.apache.spark.sql.execution.datasources.v2.V2TableWriteExec
@@ -1696,6 +1696,89 @@ class AdaptiveQueryExecSuite
       checkNoCoalescePartitions(df.repartition($"key"), REPARTITION_BY_COL)
       // partition size [1140, 1119]
       checkNoCoalescePartitions(df.sort($"key"), ENSURE_REQUIREMENTS)
+    }
+  }
+
+  test("SPARK-34980: Support coalesce partition through union") {
+    def checkResultPartition(
+        df: Dataset[Row],
+        numUnion: Int,
+        numShuffleReader: Int,
+        numPartition: Int): Unit = {
+      df.collect()
+      assert(collect(df.queryExecution.executedPlan) {
+        case u: UnionExec => u
+      }.size == numUnion)
+      assert(collect(df.queryExecution.executedPlan) {
+        case r: AQEShuffleReadExec => r
+      }.size === numShuffleReader)
+      assert(df.rdd.partitions.length === numPartition)
+    }
+
+    Seq(true, false).foreach { combineUnionEnabled =>
+      val combineUnionConfig = if (combineUnionEnabled) {
+        SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> ""
+      } else {
+        SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
+          "org.apache.spark.sql.catalyst.optimizer.CombineUnions"
+      }
+      // advisory partition size 1048576 has no special meaning, just a big enough value
+      withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+          SQLConf.COALESCE_PARTITIONS_ENABLED.key -> "true",
+          SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES.key -> "1048576",
+          SQLConf.COALESCE_PARTITIONS_MIN_PARTITION_NUM.key -> "1",
+          SQLConf.SHUFFLE_PARTITIONS.key -> "10",
+          combineUnionConfig) {
+        withTempView("t1", "t2") {
+          spark.sparkContext.parallelize((1 to 10).map(i => TestData(i, i.toString)), 2)
+            .toDF().createOrReplaceTempView("t1")
+          spark.sparkContext.parallelize((1 to 10).map(i => TestData(i, i.toString)), 4)
+            .toDF().createOrReplaceTempView("t2")
+
+          // positive test that could be coalesced
+          checkResultPartition(
+            sql("""
+                |SELECT key, count(*) FROM t1 GROUP BY key
+                |UNION ALL
+                |SELECT * FROM t2
+              """.stripMargin),
+            numUnion = 1,
+            numShuffleReader = 1,
+            numPartition = 1 + 4)
+
+          checkResultPartition(
+            sql("""
+                |SELECT key, count(*) FROM t1 GROUP BY key
+                |UNION ALL
+                |SELECT * FROM t2
+                |UNION ALL
+                |SELECT * FROM t1
+              """.stripMargin),
+            numUnion = if (combineUnionEnabled) 1 else 2,
+            numShuffleReader = 1,
+            numPartition = 1 + 4 + 2)
+
+          checkResultPartition(
+            sql("""
+                |SELECT /*+ merge(t2) */ t1.key, t2.key FROM t1 JOIN t2 ON t1.key = t2.key
+                |UNION ALL
+                |SELECT key, count(*) FROM t2 GROUP BY key
+                |UNION ALL
+                |SELECT * FROM t1
+              """.stripMargin),
+            numUnion = if (combineUnionEnabled) 1 else 2,
+            numShuffleReader = 3,
+            numPartition = 1 + 1 + 2)
+
+          // negative test
+          checkResultPartition(
+            sql("SELECT * FROM t1 UNION ALL SELECT * FROM t2"),
+            numUnion = if (combineUnionEnabled) 1 else 1,
+            numShuffleReader = 0,
+            numPartition = 2 + 4
+          )
+        }
+      }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Split plan into several groups, and every child of union is a new group
- Coalesce paritition for every group

### Why are the changes needed?

#### First Issue
The rule `CoalesceShufflePartitions` can only coalesce paritition if
* leaf node is ShuffleQueryStage
* all shuffle have same partition number

With `Union`, it might break the assumption. Let's say we have such plan
```
Union
   HashAggregate
      ShuffleQueryStage
   FileScan
```
`CoalesceShufflePartitions` can not optimize it and the result partition would be `shuffle partition + FileScan partition` which can be quite lagre.

It's better to support partial optimize with `Union`.

#### Second Issue
the coalesce partition formule used the **sum value** as the total input size and it's not friendly for union, see
```
// ShufflePartitionsUtil.coalescePartitions
val totalPostShuffleInputSize = mapOutputStatistics.flatMap(_.map(_.bytesByPartitionId.sum)).sum
```

So for such case:
```
Union
   HashAggregate
      ShuffleQueryStage
   HashAggregate
      ShuffleQueryStage
```
The `CoalesceShufflePartitions` rule will return an unexpected partition number.

### Does this PR introduce _any_ user-facing change?

Probably yes, the result partition might changed.

### How was this patch tested?

Add test.

Closes #32084 from ulysses-you/SPARK-34980.

Lead-authored-by: ulysses-you <ulyssesyou18@gmail.com>
Co-authored-by: ulysses <ulyssesyou18@gmail.com>
Co-authored-by: Wenchen Fan <wenchen@databricks.com>
Signed-off-by: Wenchen Fan <wenchen@databricks.com>

(cherry picked from commit 0e23bd7b7c6e6c0fb359fc2b9adb8538a56b9865)

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
