### PR TITLE
AL-4757 Fix hive3 use tez, spark sql scan file is null

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningAwareFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningAwareFileIndex.scala
@@ -17,14 +17,18 @@
 
 package org.apache.spark.sql.execution.datasources
 
+import java.io.FileNotFoundException
+
 import scala.collection.mutable
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs._
+import org.apache.hadoop.fs.viewfs.ViewFileSystem
+import org.apache.hadoop.hdfs.DistributedFileSystem
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.{expressions, InternalRow}
+import org.apache.spark.sql.catalyst._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, DateTimeUtils}
 import org.apache.spark.sql.types.StructType
@@ -87,13 +91,42 @@ abstract class PartitioningAwareFileIndex(
 
             case None =>
               // Directory does not exist, or has no children files
-              Nil
+              logInfo(s"can't get path from leafDirToChildrenFiles, maybe is subdir")
+              val fs = path.getFileSystem(hadoopConf)
+              val statuses: Array[FileStatus] = listFileStatus(fs, path)
+              statuses.filter(s => s.isDirectory)
+                .map(dir => listFileStatus(fs, dir.getPath))
+                .flatMap(ss => ss.filter(f => matchPathPattern(f) && isNonEmptyFile(f)))
           }
           PartitionDirectory(values, files)
       }
     }
     logTrace("Selected files after partition pruning:\n\t" + selectedPartitions.mkString("\n\t"))
     selectedPartitions
+  }
+
+  def listFileStatus(fs: FileSystem, path: Path): Array[FileStatus] = {
+    if (fs.exists(path)) {
+      val statuses: Array[FileStatus] = try {
+        fs match {
+          case _: DistributedFileSystem | _: ViewFileSystem
+            if !sparkSession.sessionState.conf.ignoreMissingFiles =>
+            val remoteIter = fs.listLocatedStatus(path)
+            new Iterator[LocatedFileStatus]() {
+              def next(): LocatedFileStatus = remoteIter.next
+              def hasNext(): Boolean = remoteIter.hasNext
+            }.toArray
+          case _ => fs.listStatus(path)
+        }
+      } catch {
+        case _: FileNotFoundException =>
+          logWarning(s"The directory $path was not found. Was it deleted very recently?")
+          Array.empty[FileStatus]
+      }
+      statuses
+    } else {
+      Array.empty[FileStatus]
+    }
   }
 
   /** Returns the list of files that will be read when scanning this relation. */
@@ -103,6 +136,7 @@ abstract class PartitioningAwareFileIndex(
   override def sizeInBytes: Long = allFiles().map(_.getLen).sum
 
   def allFiles(): Seq[FileStatus] = {
+    //
     val files = if (partitionSpec().partitionColumns.isEmpty && !recursiveFileLookup) {
       // For each of the root input paths, get the list of files inside them
       rootPaths.flatMap { path =>
@@ -125,9 +159,17 @@ abstract class PartitioningAwareFileIndex(
         // 2. The path is a file, then it will be present in leafFiles. Include this path.
         // 3. The path is a directory, but has no children files. Do not include this path.
 
-        leafDirToChildrenFiles.get(qualifiedPath)
-          .orElse { leafFiles.get(qualifiedPath).map(Array(_)) }
+        var result = leafDirToChildrenFiles.get(qualifiedPath)
+          .orElse {leafFiles.get(qualifiedPath).map(Array(_))}
           .getOrElse(Array.empty)
+        if(result.isEmpty) {
+          val fs = qualifiedPath.getFileSystem(hadoopConf)
+          val statuses: Array[FileStatus] = listFileStatus(fs, path)
+          result = statuses.filter(s => s.isDirectory)
+            .map(dir => listFileStatus(fs, dir.getPath))
+            .flatMap(ss => ss.filter(f => matchPathPattern(f)))
+        }
+        result
       }
     } else {
       leafFiles.values.toSeq


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
