### PR TITLE
AL-4757 when refresh InMemoryFileIndex, can recursiveDirChildrenFiles

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1364,9 +1364,9 @@ object SQLConf {
   val RECURSIVE_FILE_LOOKUP =
     buildConf("spark.sql.sources.recursiveFileLookup")
       .doc("If dynamic partitioning is used to write the output of UNION or UNION ALL " +
-        "queries into ORC files with hive.merge.tezfiles=true, HIVE-17275 add a sub dir " +
-        "in table or partition location. If true, Spark will fetch all files on " +
-        "each location dir and sub dir.")
+        "queries into table files with hive.execution.engine=tez, HIVE-17275 add a sub dir " +
+        "in table or partition location. If true, Spark will fetch all files on each location" +
+        " dir and sub dir. Default value is false, Spark just fetch files on each location dir")
       .version("3.2.0")
       .internal()
       .booleanConf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1361,6 +1361,17 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val RECURSIVE_FILE_LOOKUP =
+    buildConf("spark.sql.sources.recursiveFileLookup")
+      .doc("If dynamic partitioning is used to write the output of UNION or UNION ALL " +
+        "queries into ORC files with hive.merge.tezfiles=true, HIVE-17275 add a sub dir " +
+        "in table or partition location. If true, Spark will fetch all files on " +
+        "each location dir and sub dir.")
+      .version("3.2.0")
+      .internal()
+      .booleanConf
+      .createWithDefault(false)
+
   // Whether to automatically resolve ambiguity in join conditions for self-joins.
   // See SPARK-6231.
   val DATAFRAME_SELF_JOIN_AUTO_RESOLVE_AMBIGUITY =
@@ -4234,6 +4245,8 @@ class SQLConf extends Serializable with Logging {
   def castDatetimeToString: Boolean = getConf(SQLConf.LEGACY_CAST_DATETIME_TO_STRING)
 
   def ignoreDataLocality: Boolean = getConf(SQLConf.IGNORE_DATA_LOCALITY)
+
+  def recursiveFileLookup: Boolean = getConf(SQLConf.RECURSIVE_FILE_LOOKUP)
 
   def csvFilterPushDown: Boolean = getConf(CSV_FILTER_PUSHDOWN_ENABLED)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
@@ -102,7 +102,7 @@ class InMemoryFileIndex(
     cachedPartitionSpec = null
   }
 
-  private def recursiveDirChildrenFiles(files: mutable.LinkedHashSet[FileStatus])
+  def recursiveDirChildrenFiles(files: mutable.LinkedHashSet[FileStatus])
   : Map[Path, Array[FileStatus]] = {
     // rootPaths is table / partition location
     val rootParents = rootPaths.map(_.getParent).toSet

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
@@ -94,8 +94,27 @@ class InMemoryFileIndex(
     val files = listLeafFiles(rootPaths)
     cachedLeafFiles =
       new mutable.LinkedHashMap[Path, FileStatus]() ++= files.map(f => f.getPath -> f)
-    cachedLeafDirToChildrenFiles = files.toArray.groupBy(_.getPath.getParent)
+    cachedLeafDirToChildrenFiles = if (sparkSession.sessionState.conf.recursiveFileLookup) {
+      recursiveDirChildrenFiles(files)
+    } else {
+      files.toArray.groupBy(_.getPath.getParent)
+    }
     cachedPartitionSpec = null
+  }
+
+  private def recursiveDirChildrenFiles(files: mutable.LinkedHashSet[FileStatus])
+  : Map[Path, Array[FileStatus]] = {
+    // rootPaths is table / partition location
+    val rootParents = rootPaths.map(_.getParent).toSet
+    val reorganized = new mutable.LinkedHashMap[Path, mutable.LinkedHashSet[FileStatus]]()
+    files.foreach { f => // f is a file, not a directory.
+      var parent = f.getPath.getParent
+      while (parent != null && !rootParents.contains(parent)) {
+        reorganized.getOrElseUpdate(parent, new mutable.LinkedHashSet[FileStatus]()).add(f)
+        parent = parent.getParent
+      }
+    }
+    reorganized.mapValues(_.toArray).toMap
   }
 
   override def equals(other: Any): Boolean = other match {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
