### PR TITLE
KE-35241 Reduce the output partition of output stage to avoid produci…

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -601,6 +601,15 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val DATAWRITE_PARTITION_SIZE_IN_BYTES =
+    buildConf("spark.sql.adaptive.dataWritePartitionSizeInBytes")
+      .doc("The advisory size in bytes of the shuffle partition during adaptive optimization " +
+        s"(when ${ADAPTIVE_EXECUTION_ENABLED.key} and ${COALESCE_PARTITIONS_ENABLED.key} is " +
+        s"true). It takes effect the finalStage with `DataWritingCommand` or `V2TableWriteExec` " +
+        s"coalesces small shuffle partitions or splits skewed shuffle partition")
+      .version("3.3.0")
+      .fallbackConf(ADVISORY_PARTITION_SIZE_IN_BYTES)
+
   val COALESCE_PARTITIONS_PARALLELISM_FIRST =
     buildConf("spark.sql.adaptive.coalescePartitions.parallelismFirst")
       .doc("When true, Spark does not respect the target size specified by " +
@@ -2697,6 +2706,18 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val REPARTITION_WRITING_DATASOURCE =
+    buildConf("spark.sql.sources.repartitionWritingDataSource")
+      .internal()
+      .doc("Add a repartition before writing Spark SQL Data Sources. It supports three patterns:" +
+        "1. Repartition by none when writing normal table/directory. " +
+        "2. Repartition by dynamic partition column when writing dynamic partition " +
+        "table/directory. 3. Repartition by bucket column with bucket number and sort by sort " +
+        "column when writing bucket table/directory.")
+      .version("3.3.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val NESTED_SCHEMA_PRUNING_ENABLED =
     buildConf("spark.sql.optimizer.nestedSchemaPruning.enabled")
       .internal()
@@ -3890,6 +3911,8 @@ class SQLConf extends Serializable with Logging {
   def stringRedactionPattern: Option[Regex] = getConf(SQL_STRING_REDACTION_PATTERN)
 
   def sortBeforeRepartition: Boolean = getConf(SORT_BEFORE_REPARTITION)
+
+  def repartitionWritingDataSource: Boolean = getConf(REPARTITION_WRITING_DATASOURCE)
 
   def topKSortFallbackThreshold: Int = getConf(TOP_K_SORT_FALLBACK_THRESHOLD)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -39,6 +39,8 @@ import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec._
 import org.apache.spark.sql.execution.bucketing.DisableUnnecessaryBucketedScan
+import org.apache.spark.sql.execution.command.DataWritingCommandExec
+import org.apache.spark.sql.execution.datasources.v2.V2TableWriteExec
 import org.apache.spark.sql.execution.exchange._
 import org.apache.spark.sql.execution.ui.{SparkListenerSQLAdaptiveExecutionUpdate, SparkListenerSQLAdaptiveSQLMetricUpdates, SQLPlanMetric}
 import org.apache.spark.sql.internal.SQLConf
@@ -138,11 +140,32 @@ case class AdaptiveSparkPlanExec(
     collapseCodegenStagesRule
   )
 
+  private lazy val hasWriterCommand = context.qe.sparkPlan match {
+    case _: DataWritingCommandExec | _: V2TableWriteExec => true
+    case _ => false
+  }
+
   private def optimizeQueryStage(
       plan: SparkPlan,
       isFinalStage: Boolean): SparkPlan = context.qe.withCteMap {
     val optimized = queryStageOptimizerRules.foldLeft(plan) { case (latestPlan, rule) =>
-      val applied = rule.apply(latestPlan)
+      // Use a new partition size for the finalStage with `DataWritingCommand` or `V2TableWriteExec`
+      // to avoid small files.
+
+      // Before that, the partition size of the finalStage with `DataWritingCommand` or
+      // `V2TableWriteExec` may use the ADVISORY_PARTITION_SIZE_IN_BYTES which is smaller one and
+      // may produce some small files, it may bad for production, we should use a new partition
+      // size for the finalStage with `DataWritingCommand` or `V2TableWriteExec` to avoid small
+      // files.
+      val applied = if (isFinalStage && hasWriterCommand) {
+        rule match {
+          case c: CoalesceShufflePartitions =>
+            c.copy(isDataWritingStage = true).apply(latestPlan)
+          case other => other.apply(latestPlan)
+        }
+      } else {
+        rule.apply(latestPlan)
+      }
       val result = rule match {
         case _: AQEShuffleReadRule if !applied.fastEquals(latestPlan) =>
           val distribution = if (isFinalStage) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.planning.ScanOperation
-import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoDir, InsertIntoStatement, LogicalPlan, Project}
+import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoDir, InsertIntoStatement, LogicalPlan, Project, RebalancePartitions, RepartitionByExpression, RepartitionOperation, Sort}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.streaming.StreamingRelationV2
 import org.apache.spark.sql.catalyst.util.V2ExpressionBuilder
@@ -226,6 +226,107 @@ object DataSourceAnalysis extends Rule[LogicalPlan] with CastSupport {
   }
 }
 
+/**
+ * Add a repartition before writing Spark SQL Data Sources. It supports three patterns:
+ * 1. Repartition by none when writing normal table/directory.
+ * 2. Repartition by dynamic partition column when writing dynamic partition table/directory.
+ * 3. Repartition by bucket column with bucket number and sort by sort column when writing
+ *    bucket table/directory.
+ *
+ * Note that, this rule must be run after `DataSourceAnalysis`.
+ */
+object RepartitionWritingDataSource extends Rule[LogicalPlan] {
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    if (conf.repartitionWritingDataSource) {
+      insertRepartition(plan)
+    } else {
+      plan
+    }
+  }
+
+  private def insertRepartition(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
+    case c @ CreateDataSourceTableAsSelectCommand(table, _, query, _) if c.resolved =>
+      val dynamicPartExps = resolveColumnNames(table.partitionColumnNames, query.output)
+      applyRepartition(c, table.bucketSpec, dynamicPartExps)
+
+    case i: InsertIntoHadoopFsRelationCommand if i.resolved =>
+
+      val dynamicPartExps = i.partitionColumns
+        .filterNot(p => i.staticPartitions.exists(s => conf.resolver(p.name, s._1)))
+      applyRepartition(i, i.bucketSpec, dynamicPartExps)
+
+    case i: InsertIntoDataSourceDirCommand if i.resolved && canApplyRebalancePartitions(i.query) =>
+      i.copy(query = RebalancePartitions(Nil, i.query))
+
+    // InsertIntoDataSourceCommand only accept InsertableRelation, do not need repartition.
+  }
+
+  private def applyRepartition(
+                                dataWriting: DataWritingCommand,
+                                bucketSpec: Option[BucketSpec],
+                                partitionColumns: Seq[Expression]): LogicalPlan = {
+    val query = dataWriting.query
+    (bucketSpec, partitionColumns) match {
+      case (None, partExps) if partExps.nonEmpty =>
+        query match {
+          case RepartitionByExpression(partitionExpressions, _, _)
+            if partitionExpressions == partExps =>
+            dataWriting
+          case _ =>
+            dataWriting.withNewChildren(
+              Seq(RepartitionByExpression(partExps, query, conf.numShufflePartitions)))
+        }
+
+      case (Some(bucket), partExps) =>
+        val bucketExps = partExps ++ resolveColumnNames(bucket.bucketColumnNames, query.output)
+        if (bucket.sortColumnNames.nonEmpty) {
+          val sortExps = resolveColumnNames(bucket.sortColumnNames, query.output)
+            .map(SortOrder(_, Ascending))
+          query match {
+            case Sort(order, false, RepartitionByExpression(partExpr, _, Some(bucket.numBuckets)))
+              if order == sortExps && partExpr == bucketExps =>
+              dataWriting
+            case _ =>
+              dataWriting.withNewChildren(
+                Seq(Sort(sortExps, false,
+                  RepartitionByExpression(bucketExps, query, bucket.numBuckets))))
+          }
+        } else {
+          query match {
+            case RepartitionByExpression(partExpr, _, Some(bucket.numBuckets))
+              if partExpr == bucketExps =>
+              dataWriting
+            case _ =>
+              dataWriting.withNewChildren(
+                Seq(RepartitionByExpression(bucketExps, query, bucket.numBuckets)))
+          }
+        }
+
+      case _ =>
+        if (canApplyRebalancePartitions(query)) {
+          dataWriting.withNewChildren(Seq(RebalancePartitions(Nil, query)))
+        } else {
+          dataWriting
+        }
+    }
+  }
+
+  private def resolveColumnNames(
+    columnNames: Seq[String], outputAttrs: Seq[Attribute]): Seq[NamedExpression] = {
+    columnNames.map { c =>
+      outputAttrs.resolve(c :: Nil, conf.resolver).
+        getOrElse(throw new AnalysisException(s"Cannot resolve column name $c among (" +
+          s"${outputAttrs.map(_.name).mkString(",")})."))
+    }
+  }
+
+  private def canApplyRebalancePartitions(plan: LogicalPlan): Boolean = {
+    plan match {
+      case _: RebalancePartitions | _: RepartitionOperation | _: Sort => false
+      case _ => conf.adaptiveExecutionEnabled && conf.coalesceShufflePartitionsEnabled
+    }
+  }
+}
 
 /**
  * Replaces [[UnresolvedCatalogRelation]] with concrete relation logical plans.

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
@@ -197,6 +197,7 @@ abstract class BaseSessionStateBuilder(
         PreprocessTableCreation(session) +:
         PreprocessTableInsertion +:
         DataSourceAnalysis +:
+        RepartitionWritingDataSource +:
         customPostHocResolutionRules
 
     override val extendedCheckRules: Seq[LogicalPlan => Unit] =

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
@@ -91,6 +91,7 @@ class HiveSessionStateBuilder(
         PreprocessTableInsertion +:
         DataSourceAnalysis +:
         HiveAnalysis +:
+        RepartitionWritingDataSource +:
         customPostHocResolutionRules
 
     override val extendedCheckRules: Seq[LogicalPlan => Unit] =


### PR DESCRIPTION
…ng small files

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
