### PR TITLE
AL-10373 Fix data corruption on block transfer via FetchBlockSegment

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/util/JavaUtils.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/JavaUtils.java
@@ -375,4 +375,30 @@ public class JavaUtils {
     }
   }
 
+  /**
+   * Skips the requested number of bytes from the given InputStream, or throws EOFException
+   * if not enough bytes are available.
+   * <p>
+   * Unlike {@link org.apache.commons.io.IOUtils#skipFully(InputStream, long)}, this method
+   * uses {@link InputStream#skip(long)} directly, which can be considerably more efficient
+   * for InputStream implementations that override {@code skip()} (e.g., those backed by
+   * {@link java.nio.ByteBuffer}).
+   */
+  public static void skipFully(InputStream in, long numBytes) throws IOException {
+    long remaining = numBytes;
+    while (remaining > 0) {
+      long skipped = in.skip(remaining);
+      if (skipped == 0) {
+        int b = in.read();
+        if (b == -1) {
+          throw new EOFException(
+            String.format("Not enough bytes in stream (expected %d more bytes)", remaining));
+        }
+        remaining--;
+      } else {
+        remaining -= skipped;
+      }
+    }
+  }
+
 }

--- a/common/network-common/src/main/java/org/apache/spark/network/util/JavaUtils.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/JavaUtils.java
@@ -376,23 +376,28 @@ public class JavaUtils {
   }
 
   /**
-   * Skips the requested number of bytes from the given InputStream, or throws EOFException
-   * if not enough bytes are available.
-   * <p>
-   * Unlike {@link org.apache.commons.io.IOUtils#skipFully(InputStream, long)}, this method
-   * uses {@link InputStream#skip(long)} directly, which can be considerably more efficient
-   * for InputStream implementations that override {@code skip()} (e.g., those backed by
-   * {@link java.nio.ByteBuffer}).
+   * Skips the requested number of bytes or fail if there are not enough left.
+   *
+   * @param in stream to skip
+   * @param toSkip the number of bytes to skip
+   * @throws IOException              if there is a problem reading the file
+   * @throws IllegalArgumentException if toSkip is negative
+   * @throws EOFException             if the number of bytes skipped was incorrect
    */
-  public static void skipFully(InputStream in, long numBytes) throws IOException {
-    long remaining = numBytes;
+  public static void skipFully(InputStream in, long toSkip) throws IOException {
+    if (toSkip < 0) {
+      throw new IllegalArgumentException("Bytes to skip must not be negative: " + toSkip);
+    }
+
+    long remaining = toSkip;
     while (remaining > 0) {
       long skipped = in.skip(remaining);
-      if (skipped == 0) {
+      if (skipped < 0) {
+        throw new IOException("InputStream.skip() returned negative: " + skipped);
+      } else if (skipped == 0) {
         int b = in.read();
         if (b == -1) {
-          throw new EOFException(
-            String.format("Not enough bytes in stream (expected %d more bytes)", remaining));
+          throw new EOFException("Expected bytes to skip: " + toSkip + ", actual: " + (toSkip - remaining));
         }
         remaining--;
       } else {

--- a/common/network-common/src/test/java/org/apache/spark/network/util/JavaUtilsSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/util/JavaUtilsSuite.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
+import java.io.InputStream;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class JavaUtilsSuite {
+
+  @Test
+  public void testSkipFullyZeroBytes() throws Exception {
+    byte[] data = new byte[] {1, 2, 3, 4, 5};
+    InputStream in = new ByteArrayInputStream(data);
+    JavaUtils.skipFully(in, 0);
+    assertEquals(1, in.read());
+  }
+
+  @Test
+  public void testSkipFullyWithinAvailable() throws Exception {
+    byte[] data = new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    InputStream in = new ByteArrayInputStream(data);
+    JavaUtils.skipFully(in, 3);
+    assertEquals(4, in.read());
+    assertEquals(5, in.read());
+    assertEquals(6, in.read());
+  }
+
+  @Test
+  public void testSkipFullyLargerThanSkipBuffer() throws Exception {
+    byte[] data = new byte[20000];
+    data[0] = 1;
+    data[9999] = 99;
+    data[10000] = 100;
+    data[19999] = 127;
+
+    InputStream in = new ByteArrayInputStream(data);
+    JavaUtils.skipFully(in, 10000);
+    assertEquals(100, in.read());
+  }
+
+  @Test
+  public void testSkipFullyExactSize() throws Exception {
+    byte[] data = new byte[] {1, 2, 3, 4, 5};
+    InputStream in = new ByteArrayInputStream(data);
+    JavaUtils.skipFully(in, 5);
+    assertEquals(-1, in.read());
+  }
+
+  @Test(expected = EOFException.class)
+  public void testSkipFullyBeyondEOF() throws Exception {
+    byte[] data = new byte[] {1, 2, 3};
+    InputStream in = new ByteArrayInputStream(data);
+    JavaUtils.skipFully(in, 10);
+  }
+
+  @Test
+  public void testSkipFullyThenReadRemaining() throws Exception {
+    byte[] data = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    InputStream in = new ByteArrayInputStream(data);
+    JavaUtils.skipFully(in, 7);
+    byte[] remaining = new byte[3];
+    int bytesRead = 0;
+    while (bytesRead < remaining.length) {
+      int n = in.read(remaining, bytesRead, remaining.length - bytesRead);
+      if (n == -1) break;
+      bytesRead += n;
+    }
+    assertArrayEquals(new byte[] {7, 8, 9}, remaining);
+  }
+
+  @Test
+  public void testSkipFullySkipZeroIgnoresFirstReadError() throws Exception {
+    InputStream in = new InputStream() {
+      private int remaining = 10;
+      @Override
+      public int read() {
+        if (remaining <= 0) return -1;
+        remaining--;
+        return remaining;
+      }
+      @Override
+      public long skip(long n) {
+        return 0;
+      }
+    };
+    JavaUtils.skipFully(in, 5);
+    assertEquals(4, in.read());
+  }
+}

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -53,7 +53,7 @@ import org.apache.spark.network.netty.SparkTransportConf
 import org.apache.spark.network.shuffle._
 import org.apache.spark.network.shuffle.checksum.{Cause, ShuffleChecksumHelper}
 import org.apache.spark.network.shuffle.protocol.ExecutorShuffleInfo
-import org.apache.spark.network.util.TransportConf
+import org.apache.spark.network.util.{JavaUtils, TransportConf}
 import org.apache.spark.rpc.RpcEnv
 import org.apache.spark.scheduler.ExecutorCacheTaskLocation
 import org.apache.spark.serializer.{SerializerInstance, SerializerManager}
@@ -114,9 +114,9 @@ private[spark] class ByteBufferBlockData(
 
   override def toByteBuffer(offset: Long, length: Int): ByteBuffer = {
     val inputStream = buffer.toInputStream()
-    var bytes = new Array[Byte](length)
-    inputStream.skip(offset)
-    inputStream.read(bytes)
+    val bytes = new Array[Byte](length)
+    JavaUtils.skipFully(inputStream, offset)
+    IOUtils.readFully(inputStream, bytes)
     ByteBuffer.wrap(bytes)
   }
 

--- a/core/src/main/scala/org/apache/spark/storage/DiskStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskStore.scala
@@ -27,7 +27,7 @@ import scala.collection.mutable.ListBuffer
 
 import com.google.common.io.Closeables
 import io.netty.channel.DefaultFileRegion
-import org.apache.commons.io.FileUtils
+import org.apache.commons.io.{FileUtils, IOUtils}
 
 import org.apache.spark.{SecurityManager, SparkConf}
 import org.apache.spark.internal.{config, Logging}
@@ -287,9 +287,9 @@ private[spark] class EncryptedBlockData(
 
   override def toByteBuffer(offset: Long, length: Int): ByteBuffer = {
     val in = openInputStream()
-    var bytes = new Array[Byte](length)
-    in.skip(offset)
-    in.read(bytes, 0, length)
+    val bytes = new Array[Byte](length)
+    JavaUtils.skipFully(in, offset)
+    IOUtils.readFully(in, bytes)
     ByteBuffer.wrap(bytes)
   }
 

--- a/core/src/main/scala/org/apache/spark/util/io/ChunkedByteBuffer.scala
+++ b/core/src/main/scala/org/apache/spark/util/io/ChunkedByteBuffer.scala
@@ -257,10 +257,8 @@ private[spark] class ChunkedByteBufferInputStream(
   }
 
   override def skip(bytes: Long): Long = {
-    var byteToSkip = bytes
-    while (currentChunk != null && byteToSkip > 0 ) {
+    if (currentChunk != null) {
       val amountToSkip = math.min(bytes, currentChunk.remaining).toInt
-      byteToSkip = byteToSkip - amountToSkip
       currentChunk.position(currentChunk.position() + amountToSkip)
       if (currentChunk.remaining() == 0) {
         if (chunks.hasNext) {
@@ -269,8 +267,10 @@ private[spark] class ChunkedByteBufferInputStream(
           close()
         }
       }
+      amountToSkip
+    } else {
+      0L
     }
-    bytes - byteToSkip
   }
 
   override def close(): Unit = {

--- a/core/src/test/scala/org/apache/spark/io/ChunkedByteBufferSuite.scala
+++ b/core/src/test/scala/org/apache/spark/io/ChunkedByteBufferSuite.scala
@@ -99,4 +99,69 @@ class ChunkedByteBufferSuite extends SparkFunSuite with SharedSparkContext {
     assert(bytesFromStream === bytes1.array() ++ bytes2.array())
     assert(chunkedByteBuffer.getChunks().head.position() === 0)
   }
+
+  test("toInputStream() skip within a single chunk") {
+    val bytes = ByteBuffer.wrap(Array.tabulate(100)(_.toByte))
+    val chunkedByteBuffer = new ChunkedByteBuffer(Array(bytes))
+    val inputStream = chunkedByteBuffer.toInputStream()
+
+    val skipped = inputStream.skip(30)
+    assert(skipped === 30L)
+    val remaining = new Array[Byte](70)
+    ByteStreams.readFully(inputStream, remaining)
+    assert(remaining(0) === 30.toByte)
+    assert(remaining(69) === 99.toByte)
+    assert(inputStream.read() === -1)
+  }
+
+  test("toInputStream() skip across multiple chunks") {
+    val bytes1 = ByteBuffer.wrap(Array.tabulate(20)(_.toByte))
+    val bytes2 = ByteBuffer.wrap(Array.tabulate(20)(i => (i + 20).toByte))
+    val bytes3 = ByteBuffer.wrap(Array.tabulate(20)(i => (i + 40).toByte))
+    val chunkedByteBuffer = new ChunkedByteBuffer(Array(bytes1, bytes2, bytes3))
+    val inputStream = chunkedByteBuffer.toInputStream()
+
+    var remaining = 35L
+    while (remaining > 0) {
+      val s = inputStream.skip(remaining)
+      assert(s > 0)
+      remaining -= s
+    }
+    val remainingBytes = new Array[Byte](25)
+    ByteStreams.readFully(inputStream, remainingBytes)
+    assert(remainingBytes(0) === 35.toByte)
+    assert(remainingBytes(24) === 59.toByte)
+    assert(inputStream.read() === -1)
+  }
+
+  test("toInputStream() skip exactly to chunk boundary") {
+    val bytes1 = ByteBuffer.wrap(Array.tabulate(50)(_.toByte))
+    val bytes2 = ByteBuffer.wrap(Array.tabulate(30)(i => (i + 50).toByte))
+    val chunkedByteBuffer = new ChunkedByteBuffer(Array(bytes1, bytes2))
+    val inputStream = chunkedByteBuffer.toInputStream()
+
+    val skipped = inputStream.skip(50)
+    assert(skipped === 50L)
+    assert(inputStream.read() === 50)
+  }
+
+  test("toInputStream() skip past end of stream") {
+    val bytes = ByteBuffer.wrap(Array.tabulate(10)(_.toByte))
+    val chunkedByteBuffer = new ChunkedByteBuffer(Array(bytes))
+    val inputStream = chunkedByteBuffer.toInputStream()
+
+    val skipped = inputStream.skip(100)
+    assert(skipped === 10L)
+    assert(inputStream.skip(1) === 0L)
+    assert(inputStream.read() === -1)
+  }
+
+  test("toInputStream() skip zero bytes") {
+    val bytes = ByteBuffer.wrap(Array.tabulate(10)(_.toByte))
+    val chunkedByteBuffer = new ChunkedByteBuffer(Array(bytes))
+    val inputStream = chunkedByteBuffer.toInputStream()
+
+    assert(inputStream.skip(0) === 0L)
+    assert(inputStream.read() === 0)
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
